### PR TITLE
Dont allow zeros in time_from_start to prevent the use of time_from_s…

### DIFF
--- a/arbotix_python/src/arbotix_python/follow_controller.py
+++ b/arbotix_python/src/arbotix_python/follow_controller.py
@@ -136,9 +136,9 @@ class FollowController(Controller):
             desired = [ point.positions[k] for k in indexes ]
             
             # two modes: First the transition time / total duration is specified that implies joint velocities (synchronous transition)
-            if point.time_from_start.secs > 0 or point.time_from_start.nsecs > 0:
+            if point.time_from_start.secs >= 0 or point.time_from_start.nsecs >= 0:
                 sync_transition = True
-                if len(point.velocities)>0:
+                if len(point.velocities)>0 and not all(v == 0 for v in point.velocities):
                     rospy.logwarn("Found both a nonzero time_from_start and individual joint velocities. Chosing synchronous transition w.r.t. time_from_start.")
                 endtime = start + point.time_from_start
             else: # second mode: command user-defined velocity profile until desired position is reached (consider joints separately)


### PR DESCRIPTION
…tart in end_time in follow_controller.py

This hack gets my PhantomX Pincher arm to work with the turtlebot_arm package (ver. 0.4) with the Pick and Place demo. This is because the time_from_start starts with zero in the trajectory message; and all the trajectory points have zero velocities in the beginning; and there is an extra joint for the gripper which throws off an "Invalid Joint Trajectory.. " error.
